### PR TITLE
Ad 60 seconds timer on webpage cache

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -3,6 +3,7 @@
 		root * /caddy/
 		try_files /index.json
 		header Content-Type "application/json"
+		header Cache-Control max-age=60
 		file_server {
 			status 503
 		}
@@ -14,6 +15,7 @@
 	handle {
 		root * /caddy/
 		try_files /index.html
+		header Cache-Control max-age=60
 		file_server
 	}
 


### PR DESCRIPTION
- To prevent cache from keeping maintenance page around on peoples browsers after maintenance is over